### PR TITLE
Use kill command instead of damage caused by an entity.

### DIFF
--- a/src/main/java/net/blay09/mods/hardcorerevival/HardcoreRevivalManager.java
+++ b/src/main/java/net/blay09/mods/hardcorerevival/HardcoreRevivalManager.java
@@ -167,7 +167,7 @@ public class HardcoreRevivalManager implements IHardcoreRevivalManager {
             ((ServerPlayerEntityAccessor) player).setRespawnInvulnerabilityTicks(0);
         }
 
-        player.attackEntityFrom(notRescuedInTime, player.getHealth());
+        player.onKillCommand();
         reset(player);
     }
 


### PR DESCRIPTION
Since ShieldMechanics reduces the damage you take when you have a shield in your (off)hand, it is not sufficient to make damage equal to `player.getHealth()`. Closes #55 

