### PR TITLE
Reset player before Killing them

### DIFF
--- a/shared/src/main/java/net/blay09/mods/hardcorerevival/HardcoreRevivalManager.java
+++ b/shared/src/main/java/net/blay09/mods/hardcorerevival/HardcoreRevivalManager.java
@@ -149,8 +149,8 @@ public class HardcoreRevivalManager {
 
         final var damageTypes = player.level().registryAccess().registryOrThrow(Registries.DAMAGE_TYPE);
         final var damageSource = new DamageSource(damageTypes.getHolderOrThrow(NOT_RESCUED_IN_TIME));
-        player.hurt(damageSource, Float.MAX_VALUE);
         reset(player);
+        player.hurt(damageSource, Float.MAX_VALUE);
     }
 
     public void reset(Player player) {


### PR DESCRIPTION
Changes order of operations, so the player KnockedOut state is reset before dealing the killing blow.
Fixes TwelveIterationMods/HardcoreRevival/issues/109

Confirmed that Harcore Revival functionality is not affected by this change.

#### Context
After testing the issue reported several times, what stud up for me was this part:

> Even after using option "Accept your fate", other players can still try to revive you using Hardcore Revival, until the timer time expires.

This to me was proof that the timer was not being reset as it should.
Looking at the code, the only thing that could trigger this, was the killing function, so tried to put that last in the chain, and it fixed the problem.
