### PR TITLE
✨ Respect death protection before knockout

### DIFF
--- a/common/src/main/java/net/blay09/mods/hardcorerevival/handler/KnockoutHandler.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/handler/KnockoutHandler.java
@@ -6,25 +6,38 @@ import net.blay09.mods.balm.platform.event.EventPhases;
 import net.blay09.mods.balm.platform.event.callback.LivingEntityCallback;
 import net.blay09.mods.balm.platform.event.callback.ServerPlayerCallback;
 import net.blay09.mods.balm.platform.event.callback.ServerTickCallback;
+import net.blay09.mods.hardcorerevival.HardcoreRevival;
 import net.blay09.mods.hardcorerevival.HardcoreRevivalManager;
 import net.blay09.mods.hardcorerevival.PlayerHardcoreRevivalManager;
 import net.blay09.mods.hardcorerevival.api.PlayerAboutToKnockOutEvent;
 import net.blay09.mods.hardcorerevival.config.HardcoreRevivalConfig;
+import net.blay09.mods.hardcorerevival.mixin.LivingEntityAccessor;
+import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.stats.Stats;
 import net.minecraft.tags.DamageTypeTags;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.Pose;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.component.DeathProtection;
+import net.minecraft.world.level.gameevent.GameEvent;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 
 
 public class KnockoutHandler {
+    private static boolean didLogTrinketsDeathProtectionError;
+    private static boolean didLogTrinketsDeathProtectionSyncError;
 
     public static void initialize() {
         LivingEntityCallback.Death.Before.EVENT.register(EventPhases.HIGH, KnockoutHandler::allowPlayerDeath);
@@ -45,6 +58,10 @@ public class KnockoutHandler {
             }
 
             if (isKnockoutEnabledFor(player, damageSource)) {
+                if (tryUseDeathProtection(player, damageSource)) {
+                    return false;
+                }
+
                 final var aboutToKnockOutEvent = new PlayerAboutToKnockOutEvent(player, damageSource);
                 PlayerAboutToKnockOutEvent.EVENT.invoker().accept(aboutToKnockOutEvent);
 
@@ -59,16 +76,100 @@ public class KnockoutHandler {
         return true;
     }
 
-    private static boolean holdsDeathProtectionItem(ServerPlayer player) {
-        for (final var hand : InteractionHand.values()) {
-            final var itemStack = player.getItemInHand(hand);
+    private static boolean tryUseDeathProtection(ServerPlayer player, DamageSource damageSource) {
+        if (((LivingEntityAccessor) player).callCheckTotemDeathProtection(damageSource)) {
+            return true;
+        }
+
+        if (damageSource.is(DamageTypeTags.BYPASSES_INVULNERABILITY)) {
+            return false;
+        }
+
+        return tryUseTrinketsDeathProtection(player);
+    }
+
+    private static boolean tryUseTrinketsDeathProtection(ServerPlayer player) {
+        try {
+            final var trinketsApiClass = Class.forName("dev.emi.trinkets.api.TrinketsApi", false, KnockoutHandler.class.getClassLoader());
+            final var trinketComponentClass = Class.forName("dev.emi.trinkets.api.TrinketComponent", false, KnockoutHandler.class.getClassLoader());
+            final var getTrinketComponent = findMethod(trinketsApiClass, "getTrinketComponent", 1);
+            if (getTrinketComponent == null) {
+                return false;
+            }
+
+            final var componentResult = getTrinketComponent.invoke(null, player);
+            if (!(componentResult instanceof Optional<?> optionalComponent) || optionalComponent.isEmpty()) {
+                return false;
+            }
+
+            final var component = optionalComponent.get();
+            final var foundItem = new AtomicReference<ItemStack>();
+            final var forEach = trinketComponentClass.getMethod("forEach", BiConsumer.class);
+            forEach.invoke(component, (BiConsumer<Object, ItemStack>) (slotReference, itemStack) -> {
+                if (foundItem.get() == null && itemStack.get(DataComponents.DEATH_PROTECTION) != null) {
+                    foundItem.set(itemStack);
+                }
+            });
+
+            final var itemStack = foundItem.get();
+            if (itemStack == null) {
+                return false;
+            }
+
             final var deathProtection = itemStack.get(DataComponents.DEATH_PROTECTION);
-            if (deathProtection != null) {
-                return true;
+            if (deathProtection == null) {
+                return false;
+            }
+
+            useDeathProtectionItem(player, itemStack, deathProtection);
+            trySyncTrinketsComponent(trinketsApiClass, player);
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        } catch (LinkageError | ReflectiveOperationException e) {
+            if (!didLogTrinketsDeathProtectionError) {
+                didLogTrinketsDeathProtectionError = true;
+                HardcoreRevival.logger.warn("Failed to check Trinkets death protection items", e);
+            }
+            return false;
+        }
+    }
+
+    private static Method findMethod(Class<?> type, String name, int parameterCount) {
+        for (final var method : type.getMethods()) {
+            if (method.getName().equals(name) && method.getParameterCount() == parameterCount) {
+                return method;
             }
         }
 
-        return false;
+        return null;
+    }
+
+    private static void trySyncTrinketsComponent(Class<?> trinketsApiClass, ServerPlayer player) {
+        try {
+            final var trinketComponentKey = trinketsApiClass.getField("TRINKET_COMPONENT").get(null);
+            final var sync = findMethod(trinketComponentKey.getClass(), "sync", 1);
+            if (sync != null) {
+                sync.invoke(trinketComponentKey, player);
+            }
+        } catch (LinkageError | ReflectiveOperationException e) {
+            if (!didLogTrinketsDeathProtectionSyncError) {
+                didLogTrinketsDeathProtectionSyncError = true;
+                HardcoreRevival.logger.warn("Failed to sync Trinkets death protection item consumption", e);
+            }
+        }
+    }
+
+    private static void useDeathProtectionItem(ServerPlayer player, ItemStack itemStack, DeathProtection deathProtection) {
+        final var itemStackCopy = itemStack.copy();
+        itemStack.shrink(1);
+
+        player.awardStat(Stats.ITEM_USED.get(itemStackCopy.getItem()));
+        CriteriaTriggers.USED_TOTEM.trigger(player, itemStackCopy);
+        itemStackCopy.causeUseVibration(player, GameEvent.ITEM_INTERACT_FINISH);
+        player.setHealth(1f);
+        deathProtection.applyEffects(itemStackCopy, player);
+        player.level().broadcastEntityEvent(player, (byte) 35);
     }
 
     private static boolean isKnockoutEnabledFor(ServerPlayer player, DamageSource damageSource) {
@@ -94,7 +195,7 @@ public class KnockoutHandler {
             return false;
         }
 
-        return !holdsDeathProtectionItem(player);
+        return true;
     }
 
     public static void onPlayerTick(ServerPlayer player) {


### PR DESCRIPTION
## ✨ What changed

- **Let vanilla death protection fire before Hardcore Revival knockout.**
- **Uses Minecraft's own totem activation path** for main-hand and off-hand items, preserving the normal health restore, effects, stat, advancement trigger, vibration, and pop animation.
- **Adds optional Trinkets compatibility** for death-protection items equipped in Trinkets slots, without making Trinkets a required dependency.
- **Keeps the rescue flow intact** when no death-protection item is available.

## 🧡 Why this helps

Fabric's fatal-damage hook runs **before vanilla totems get a chance to activate**, so Hardcore Revival could move a player into the knocked-out state even while they had a valid totem available. This makes death-protection items the first line of defense, and only falls back to the rescue state afterward.

## 🧪 Tested

- **In-game:** lethal damage with a totem in hand now pops the totem instead of triggering knockout.
- **Build:** `./gradlew :common:compileJava :fabric:build`

## 📦 Target

- **Minecraft:** `26.1.2`
- **Loader:** `Fabric`