### PR TITLE
Respect vanilla death protection before knockout

### DIFF
--- a/common/src/main/java/net/blay09/mods/hardcorerevival/handler/KnockoutHandler.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/handler/KnockoutHandler.java
@@ -10,12 +10,11 @@ import net.blay09.mods.hardcorerevival.HardcoreRevivalManager;
 import net.blay09.mods.hardcorerevival.PlayerHardcoreRevivalManager;
 import net.blay09.mods.hardcorerevival.api.PlayerAboutToKnockOutEvent;
 import net.blay09.mods.hardcorerevival.config.HardcoreRevivalConfig;
-import net.minecraft.core.component.DataComponents;
+import net.blay09.mods.hardcorerevival.mixin.LivingEntityAccessor;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.tags.DamageTypeTags;
-import net.minecraft.world.InteractionHand;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageTypes;
 import net.minecraft.world.entity.Entity;
@@ -45,6 +44,10 @@ public class KnockoutHandler {
             }
 
             if (isKnockoutEnabledFor(player, damageSource)) {
+                if (((LivingEntityAccessor) player).callCheckTotemDeathProtection(damageSource)) {
+                    return false;
+                }
+
                 final var aboutToKnockOutEvent = new PlayerAboutToKnockOutEvent(player, damageSource);
                 PlayerAboutToKnockOutEvent.EVENT.invoker().accept(aboutToKnockOutEvent);
 
@@ -57,18 +60,6 @@ public class KnockoutHandler {
         }
 
         return true;
-    }
-
-    private static boolean holdsDeathProtectionItem(ServerPlayer player) {
-        for (final var hand : InteractionHand.values()) {
-            final var itemStack = player.getItemInHand(hand);
-            final var deathProtection = itemStack.get(DataComponents.DEATH_PROTECTION);
-            if (deathProtection != null) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static boolean isKnockoutEnabledFor(ServerPlayer player, DamageSource damageSource) {
@@ -94,7 +85,7 @@ public class KnockoutHandler {
             return false;
         }
 
-        return !holdsDeathProtectionItem(player);
+        return true;
     }
 
     public static void onPlayerTick(ServerPlayer player) {


### PR DESCRIPTION
## Summary

- **Calls vanilla death protection before entering Hardcore Revival knockout.**
- **Removes the previous hand-only death-protection check** so Minecraft and compatible mod hooks can handle the actual protection behavior.
- **Keeps the knockout flow unchanged** when no death-protection item applies.

## Context

My previous PR included inappropriate, overcomplicated code. I am sorry for that. This version is intentionally reduced to one small change: it calls the existing `checkTotemDeathProtection` invoker that this project already exposes through `LivingEntityAccessor`, instead of trying to inspect or consume death-protection items manually.

## AI Assistance

This PR was prepared with AI assistance. I reviewed the resulting diff locally and I take responsibility for submitting it.

## Testing

- `./gradlew :fabric:clean :fabric:build`

## Maintainer Note

If there is a better way to implement this, I would appreciate your feedback and will adjust or close the PR as preferred. Also, if you would rather not receive further contributions from me, whether you consider them good or bad, please say so and I will respect that.