### PR TITLE
Fix Sable compat, resolve #184

### DIFF
--- a/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
@@ -24,7 +24,7 @@ public class MixinHooks {
     public static void handleProcessPlayerRotation(ServerPlayer player, ServerboundMovePlayerPacket packet) {
         float yaw = packet.getYRot(player.getYRot());
         float pitch = packet.getXRot(player.getXRot());
-        player.absMoveTo(player.getX(), player.getY(), player.getZ(), yaw, pitch);
+        player.absRotateTo(yaw, pitch);
     }
 
     public static boolean shouldCancelToss(Player player, ItemStack itemStack) {

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
@@ -21,6 +21,12 @@ public class MixinHooks {
         return entity instanceof Player player && PlayerHardcoreRevivalManager.isKnockedOut(player);
     }
 
+    public static void handleProcessPlayerRotation(ServerPlayer player, ServerboundMovePlayerPacket packet) {
+        float yaw = packet.getYRot(player.getYRot());
+        float pitch = packet.getXRot(player.getXRot());
+        player.absRotateTo(yaw, pitch);
+    }
+
     public static boolean shouldCancelToss(Player player, ItemStack itemStack) {
         return PlayerHardcoreRevivalManager.isKnockedOut(player) && !KnockoutRestrictionHandler.mayTossItemKnockedOut(itemStack);
     }

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/MixinHooks.java
@@ -21,12 +21,6 @@ public class MixinHooks {
         return entity instanceof Player player && PlayerHardcoreRevivalManager.isKnockedOut(player);
     }
 
-    public static void handleProcessPlayerRotation(ServerPlayer player, ServerboundMovePlayerPacket packet) {
-        float yaw = packet.getYRot(player.getYRot());
-        float pitch = packet.getXRot(player.getXRot());
-        player.absRotateTo(yaw, pitch);
-    }
-
     public static boolean shouldCancelToss(Player player, ItemStack itemStack) {
         return PlayerHardcoreRevivalManager.isKnockedOut(player) && !KnockoutRestrictionHandler.mayTossItemKnockedOut(itemStack);
     }

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
@@ -8,19 +8,26 @@ import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
 public class EntityMixin {
 
-    @Inject(method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V", at = @At("HEAD"), cancellable = true)
-    private void move(MoverType type, Vec3 pos, CallbackInfo ci) {
-        Entity entity = (Entity) (Object) this;
-        if (MixinHooks.shouldCancelMovement(entity)) {
-            ci.cancel();
-        }
-    }
+//    @ModifyVariable(
+//            method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
+//            at = @At("HEAD"),
+//            argsOnly = true,
+//            index = 2 // 0 = this, 1 = MoverType, 2 = Vec3
+//    )
+//    private Vec3 cancelMovement(Vec3 pos) {
+//        Entity entity = (Entity) (Object) this;
+//        if (MixinHooks.shouldCancelMovement(entity)) {
+//            return Vec3.ZERO;
+//        }
+//        return pos;
+//    }
 
     @Inject(method = "fireImmune()Z", at = @At("HEAD"), cancellable = true)
     private void fireImmune(CallbackInfoReturnable<Boolean> cir) {

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
@@ -2,14 +2,9 @@ package net.blay09.mods.hardcorerevival.mixin;
 
 import net.blay09.mods.hardcorerevival.MixinHooks;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.MoverType;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/EntityMixin.java
@@ -15,20 +15,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Entity.class)
 public class EntityMixin {
 
-//    @ModifyVariable(
-//            method = "move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V",
-//            at = @At("HEAD"),
-//            argsOnly = true,
-//            index = 2 // 0 = this, 1 = MoverType, 2 = Vec3
-//    )
-//    private Vec3 cancelMovement(Vec3 pos) {
-//        Entity entity = (Entity) (Object) this;
-//        if (MixinHooks.shouldCancelMovement(entity)) {
-//            return Vec3.ZERO;
-//        }
-//        return pos;
-//    }
-
     @Inject(method = "fireImmune()Z", at = @At("HEAD"), cancellable = true)
     private void fireImmune(CallbackInfoReturnable<Boolean> cir) {
         Entity entity = (Entity) (Object) this;

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/PlayerMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/PlayerMixin.java
@@ -1,14 +1,38 @@
 package net.blay09.mods.hardcorerevival.mixin;
 
 import net.blay09.mods.hardcorerevival.MixinHooks;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Player.class)
 public class PlayerMixin {
+
+    @ModifyVariable(
+            method = "Lnet/minecraft/world/entity/player/Player;travel(Lnet/minecraft/world/phys/Vec3;)V",
+            at = @At("HEAD"),
+            argsOnly = true,
+            index = 1
+    )
+    private Vec3 cancelMovement(Vec3 pTravelVector) {
+        if (MixinHooks.shouldCancelMovement((Entity) (Object) this)) {
+            return Vec3.ZERO;
+        }
+        return pTravelVector;
+    }
+
+    @Inject(method = "Lnet/minecraft/world/entity/player/Player;jumpFromGround()V", at = @At("HEAD"), cancellable = true)
+    private void cancelJump(CallbackInfo ci) {
+        if (MixinHooks.shouldCancelMovement((Entity) (Object) this)) {
+            ci.cancel();
+        }
+    }
 
     @Inject(method = "isHurt()Z", at = @At("HEAD"), cancellable = true)
     private void isHurt(CallbackInfoReturnable<Boolean> ci) {

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
@@ -14,14 +14,13 @@ import static org.spongepowered.asm.mixin.injection.At.Shift;
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin {
 
-    @Inject(method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ServerboundMovePlayerPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
-    public void handleMovePlayer(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
-        ServerGamePacketListenerImpl netHandler = (ServerGamePacketListenerImpl) (Object) this;
-        if (MixinHooks.shouldCancelMovement(netHandler.player)) {
-            MixinHooks.handleProcessPlayerRotation(netHandler.player, packet);
-            ci.cancel();
-        }
-    }
+//    @Inject(method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ServerboundMovePlayerPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
+//    public void handleMovePlayer(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
+//        ServerGamePacketListenerImpl netHandler = (ServerGamePacketListenerImpl) (Object) this;
+//        if (MixinHooks.shouldCancelMovement(netHandler.player)) {
+//            MixinHooks.handleProcessPlayerRotation(netHandler.player, packet);
+//        }
+//    }
 
     @Inject(method = "handlePlayerAction(Lnet/minecraft/network/protocol/game/ServerboundPlayerActionPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
     public void handlePlayerAction(ServerboundPlayerActionPacket packet, CallbackInfo ci) {

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
@@ -14,14 +14,6 @@ import static org.spongepowered.asm.mixin.injection.At.Shift;
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin {
 
-//    @Inject(method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ServerboundMovePlayerPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
-//    public void handleMovePlayer(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
-//        ServerGamePacketListenerImpl netHandler = (ServerGamePacketListenerImpl) (Object) this;
-//        if (MixinHooks.shouldCancelMovement(netHandler.player)) {
-//            MixinHooks.handleProcessPlayerRotation(netHandler.player, packet);
-//        }
-//    }
-
     @Inject(method = "handlePlayerAction(Lnet/minecraft/network/protocol/game/ServerboundPlayerActionPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
     public void handlePlayerAction(ServerboundPlayerActionPacket packet, CallbackInfo ci) {
         final var netHandler = (ServerGamePacketListenerImpl) (Object) this;

--- a/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
+++ b/common/src/main/java/net/blay09/mods/hardcorerevival/mixin/ServerGamePacketListenerImplMixin.java
@@ -14,6 +14,15 @@ import static org.spongepowered.asm.mixin.injection.At.Shift;
 @Mixin(ServerGamePacketListenerImpl.class)
 public class ServerGamePacketListenerImplMixin {
 
+    @Inject(method = "handleMovePlayer(Lnet/minecraft/network/protocol/game/ServerboundMovePlayerPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
+    public void handleMovePlayer(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
+        ServerGamePacketListenerImpl netHandler = (ServerGamePacketListenerImpl) (Object) this;
+        if (MixinHooks.shouldCancelMovement(netHandler.player)) {
+            MixinHooks.handleProcessPlayerRotation(netHandler.player, packet);
+            ci.cancel();
+        }
+    }
+
     @Inject(method = "handlePlayerAction(Lnet/minecraft/network/protocol/game/ServerboundPlayerActionPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/PacketUtils;ensureRunningOnSameThread(Lnet/minecraft/network/protocol/Packet;Lnet/minecraft/network/PacketListener;Lnet/minecraft/server/level/ServerLevel;)V", shift = Shift.AFTER), cancellable = true)
     public void handlePlayerAction(ServerboundPlayerActionPacket packet, CallbackInfo ci) {
         final var netHandler = (ServerGamePacketListenerImpl) (Object) this;


### PR DESCRIPTION
This PR is a follow-up for #184. It's a bit larger of a change than I was hoping for so I wouldn't merge it without further investigation/testing. Plus I imagine that you'll have better insight into the difference between this mixin and the original than I do. I'm running this fork on my private SMP with my friends, so will update this PR if any further issues come up.

## The Issue
Reviving on a Sable sublevel sometimes shunts the player through the floor. After further testing, this seems to be because of Hardcore Revival's mixin that cancels `Entity$move` preventing Sable from doing its usual collision detection.

## The Solution
I've replaced the `Entity$move` mixin with a less invasive mixin on `Player$travel`. I think this better matches the intended logic as well: presumably we want the knockdown state to prevent player-driven movements, not all possible movement of the player entity. I've tested and confirmed that this new mixin still prevents players from moving while downed, and also seems to resolve the underlying issue.